### PR TITLE
Fix monitor Z-centering and update GPU types in docstrings

### DIFF
--- a/hyperwave_community/monitors.py
+++ b/hyperwave_community/monitors.py
@@ -1122,8 +1122,8 @@ def add_monitors_at_position(
             effective_height_factor = height_factor if height_factor is not None else width_factor
             desired_z_half_extent = int(wg['width'] * effective_height_factor) // 2
 
-            # Center in Z, clamp each edge independently
-            z_center = z_dim // 2
+            # Center in Z on the detected waveguide core, clamp each edge independently
+            z_center = wg.get('z_core', z_dim // 2)  # Use detected core, fallback to middle
             z_start = max(0, z_center - desired_z_half_extent)
             z_end = min(z_dim, z_center + desired_z_half_extent)
             z_height = z_end - z_start
@@ -1180,8 +1180,8 @@ def add_monitors_at_position(
             effective_height_factor = height_factor if height_factor is not None else width_factor
             desired_z_half_extent = int(wg['width'] * effective_height_factor) // 2
 
-            # Center in Z, clamp each edge independently
-            z_center = z_dim // 2
+            # Center in Z on the detected waveguide core, clamp each edge independently
+            z_center = wg.get('z_core', z_dim // 2)  # Use detected core, fallback to middle
             z_start = max(0, z_center - desired_z_half_extent)
             z_end = min(z_dim, z_center + desired_z_half_extent)
             z_height = z_end - z_start

--- a/hyperwave_community/sources.py
+++ b/hyperwave_community/sources.py
@@ -384,7 +384,8 @@ def create_gaussian_source(
         simulation_steps: Number of FDTD time steps for source generation.
             The simulation will converge to a relatively low error at around this step count.
         check_every_n: Convergence check interval.
-        gpu_type: GPU type to use (H100, A100, A10G, L4).
+        gpu_type: GPU type to use. Options: B200, H200, H100, A100-80GB, A100-40GB, L40S, L4, A10G, T4.
+            Default: H100.
         api_key: API authentication key. If None, reads from HYPERWAVE_API_KEY
             environment variable.
 


### PR DESCRIPTION
Monitor Z-centering fix:
- Use detected z_core from waveguide detection instead of hardcoded z_dim//2
- Monitors now properly center on waveguide core at any Z height
- Fixes clipping issues where monitors would cut off top of waveguide

GPU docstring updates:
- Update create_gaussian_source() to list all available GPU types
- Options: B200, H200, H100, A100-80GB, A100-40GB, L40S, L4, A10G, T4