### PR TITLE
Add checkpoint save/load/resume, fix off-by-one

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,84 @@
+"""Fixtures for integration tests against mock server."""
+
+import os
+import sys
+import time
+import subprocess
+
+import pytest
+import requests
+
+MOCK_SERVER_PORT = 8765
+MOCK_SERVER_URL = f"http://localhost:{MOCK_SERVER_PORT}"
+TEST_API_KEY = "test-api-key-12345"
+
+MOCK_SERVER_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..", "..", "..", "hyperwave-cloud", "tests", "mock_server.py"
+)
+
+
+@pytest.fixture(scope="session")
+def mock_server():
+    """Start mock server for the test session, kill after."""
+    # Check if server already running
+    try:
+        r = requests.get(f"{MOCK_SERVER_URL}/health", timeout=1)
+        if r.status_code == 200:
+            yield MOCK_SERVER_URL
+            return
+    except requests.ConnectionError:
+        pass
+
+    server_path = os.path.abspath(MOCK_SERVER_PATH)
+    if not os.path.exists(server_path):
+        pytest.skip(f"Mock server not found at {server_path}")
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "mock_server:app",
+         "--host", "0.0.0.0", "--port", str(MOCK_SERVER_PORT)],
+        cwd=os.path.dirname(server_path),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    for _ in range(30):
+        try:
+            r = requests.get(f"{MOCK_SERVER_URL}/health", timeout=1)
+            if r.status_code == 200:
+                break
+        except requests.ConnectionError:
+            pass
+        time.sleep(0.5)
+    else:
+        proc.kill()
+        pytest.fail("Mock server failed to start")
+
+    yield MOCK_SERVER_URL
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+@pytest.fixture
+def tmp_dir(tmp_path):
+    return str(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def reset_billing(mock_server):
+    requests.post(f"{mock_server}/billing/reset")
+    yield
+
+
+@pytest.fixture
+def configure_sdk(mock_server):
+    import hyperwave_community as hwc
+    from hyperwave_community.api_client import _API_CONFIG
+    _API_CONFIG['api_key'] = TEST_API_KEY
+    _API_CONFIG['api_url'] = mock_server
+    _API_CONFIG['gateway_url'] = None
+    return hwc

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,41 @@
+"""Shared test constants and helpers."""
+
+import numpy as np
+
+NUM_STEPS = 30
+THETA_SHAPE = (20, 20)
+BASELINE_FILE = "/tmp/test_baseline_30steps.npz"
+
+
+def make_test_inputs():
+    rng = np.random.RandomState(123)
+    theta = rng.rand(*THETA_SHAPE).astype(np.float32) * 0.5 + 0.25
+    source = rng.rand(2, 6, 1, 2, 2).astype(np.float32)
+    return theta, source
+
+
+def run_opt(hwc, theta, source, num_steps, checkpoint=None, auto_checkpoint=False, checkpoint_path=None):
+    kwargs = dict(
+        source_field=source,
+        source_offset=(0, 0, 0),
+        freq_band=(0.196, 0.209, 2),
+        structure_spec={"layers_info": [], "construction_params": {"grid_shape": list(THETA_SHAPE)}},
+        loss_monitor_shape=(1, 1, 1),
+        loss_monitor_offset=(0, 0, 0),
+        design_monitor_shape=(1, 1, 1),
+        design_monitor_offset=(0, 0, 0),
+        mode_field=source,
+        input_power=1.0,
+        mode_cross_power=0.5,
+        num_steps=num_steps,
+        learning_rate=0.01,
+        gpu_type="B200",
+        auto_checkpoint=auto_checkpoint,
+    )
+    if checkpoint_path:
+        kwargs['checkpoint_path'] = checkpoint_path
+    if checkpoint is not None:
+        kwargs['checkpoint'] = checkpoint
+    else:
+        kwargs['theta'] = theta
+    return list(hwc.run_optimization(**kwargs))

--- a/tests/integration/test_01_baseline.py
+++ b/tests/integration/test_01_baseline.py
@@ -1,0 +1,48 @@
+"""Test 01: Full 30-step baseline run."""
+
+import numpy as np
+from .helpers import make_test_inputs, run_opt, NUM_STEPS, THETA_SHAPE, BASELINE_FILE
+
+
+class TestBaseline:
+    def test_runs_all_steps(self, configure_sdk):
+        theta, source = make_test_inputs()
+        results = run_opt(configure_sdk, theta, source, NUM_STEPS)
+        assert len(results) == NUM_STEPS
+
+    def test_loss_decreases(self, configure_sdk):
+        theta, source = make_test_inputs()
+        results = run_opt(configure_sdk, theta, source, NUM_STEPS)
+        losses = [r['loss'] for r in results]
+        assert losses[-1] < losses[0]
+
+    def test_step_numbers_sequential(self, configure_sdk):
+        theta, source = make_test_inputs()
+        results = run_opt(configure_sdk, theta, source, NUM_STEPS)
+        steps = [r['step'] for r in results]
+        assert steps == list(range(NUM_STEPS))
+
+    def test_theta_present(self, configure_sdk):
+        theta, source = make_test_inputs()
+        results = run_opt(configure_sdk, theta, source, NUM_STEPS)
+        for r in results:
+            assert 'theta' in r
+            assert r['theta'].shape == THETA_SHAPE
+
+    def test_opt_state_present(self, configure_sdk):
+        theta, source = make_test_inputs()
+        results = run_opt(configure_sdk, theta, source, NUM_STEPS)
+        for r in results:
+            assert 'opt_state_b64' in r
+
+    def test_save_baseline(self, configure_sdk):
+        """Save baseline for comparison tests."""
+        theta, source = make_test_inputs()
+        results = run_opt(configure_sdk, theta, source, NUM_STEPS)
+        np.savez(
+            BASELINE_FILE,
+            losses=np.array([r['loss'] for r in results]),
+            efficiencies=np.array([r['efficiency'] for r in results]),
+            grad_maxes=np.array([r['grad_max'] for r in results]),
+            thetas=np.stack([r['theta'] for r in results]),
+        )

--- a/tests/integration/test_02_deterministic_resume.py
+++ b/tests/integration/test_02_deterministic_resume.py
@@ -1,0 +1,85 @@
+"""Test 02: Deterministic resume - verify optimizer state continuity."""
+
+import os
+import numpy as np
+import pytest
+from .helpers import make_test_inputs, run_opt, NUM_STEPS, THETA_SHAPE
+
+SPLIT_STEP = 15
+
+
+class TestDeterministicResume:
+    def test_resume_loss_continuity(self, configure_sdk, tmp_dir):
+        """Loss should not spike on resume; phase 2 starts near where phase 1 ended."""
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        ckpt = os.path.join(tmp_dir, "ckpt.npz")
+
+        r1 = run_opt(hwc, theta, source, SPLIT_STEP)
+        assert len(r1) == SPLIT_STEP
+        hwc.save_checkpoint(r1, ckpt)
+
+        r2 = run_opt(hwc, None, source, NUM_STEPS, checkpoint=ckpt)
+        assert len(r2) == NUM_STEPS - SPLIT_STEP
+
+        # Loss at start of phase 2 should be close to loss at end of phase 1
+        last_p1_loss = r1[-1]['loss']
+        first_p2_loss = r2[0]['loss']
+        # Allow some movement since LR schedule restarts, but no huge spike
+        assert first_p2_loss < last_p1_loss * 1.5, (
+            f"Loss spiked on resume: {last_p1_loss:.6f} -> {first_p2_loss:.6f}"
+        )
+
+        # Loss should generally decrease across the full run
+        all_losses = [r['loss'] for r in r1 + r2]
+        assert all_losses[-1] < all_losses[0], "Loss did not decrease overall"
+
+    def test_phase1_matches_independent_run(self, configure_sdk, tmp_dir):
+        """Phase 1 of a resume run should exactly match an independent run of the same length."""
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        ckpt = os.path.join(tmp_dir, "ckpt.npz")
+
+        # Run 1: 15 steps then checkpoint
+        r1 = run_opt(hwc, theta, source, SPLIT_STEP)
+        hwc.save_checkpoint(r1, ckpt)
+
+        # Run 2: independent 15 steps from same initial conditions
+        r_independent = run_opt(hwc, theta, source, SPLIT_STEP)
+
+        losses_r1 = np.array([r['loss'] for r in r1])
+        losses_ind = np.array([r['loss'] for r in r_independent])
+        np.testing.assert_allclose(losses_r1, losses_ind, rtol=1e-5,
+                                   err_msg="Phase 1 not reproducible")
+
+    def test_theta_restored_on_resume(self, configure_sdk, tmp_dir):
+        """Theta at start of phase 2 should match theta at end of phase 1."""
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        ckpt = os.path.join(tmp_dir, "ckpt.npz")
+
+        r1 = run_opt(hwc, theta, source, SPLIT_STEP)
+        hwc.save_checkpoint(r1, ckpt)
+        r2 = run_opt(hwc, None, source, NUM_STEPS, checkpoint=ckpt)
+
+        last_theta_p1 = r1[-1]['theta']
+        first_theta_p2 = r2[0]['theta']
+        # The first step of phase 2 uses restored theta from checkpoint,
+        # but returns theta AFTER the update. So just check they're close.
+        np.testing.assert_allclose(
+            first_theta_p2, last_theta_p1, atol=0.01,
+            err_msg="Theta not properly restored on resume"
+        )
+
+    def test_step_numbers_correct(self, configure_sdk, tmp_dir):
+        """Step numbers should be continuous across resume."""
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        ckpt = os.path.join(tmp_dir, "ckpt.npz")
+
+        r1 = run_opt(hwc, theta, source, SPLIT_STEP)
+        hwc.save_checkpoint(r1, ckpt)
+        r2 = run_opt(hwc, None, source, NUM_STEPS, checkpoint=ckpt)
+
+        all_steps = [r['step'] for r in r1 + r2]
+        assert all_steps == list(range(NUM_STEPS))

--- a/tests/integration/test_03_checkpoint_integrity.py
+++ b/tests/integration/test_03_checkpoint_integrity.py
@@ -1,0 +1,70 @@
+"""Test 03: Checkpoint integrity."""
+
+import os
+import numpy as np
+import pytest
+from .helpers import make_test_inputs, run_opt, THETA_SHAPE
+
+
+class TestCheckpointIntegrity:
+    def _run_and_save(self, hwc, path, num_steps=15):
+        theta, source = make_test_inputs()
+        results = run_opt(hwc, theta, source, num_steps)
+        hwc.save_checkpoint(results, path)
+        return results
+
+    def test_file_created(self, configure_sdk, tmp_dir):
+        path = os.path.join(tmp_dir, "ckpt.npz")
+        self._run_and_save(configure_sdk, path)
+        assert os.path.exists(path)
+
+    def test_required_keys(self, configure_sdk, tmp_dir):
+        path = os.path.join(tmp_dir, "ckpt.npz")
+        self._run_and_save(configure_sdk, path)
+        ckpt = configure_sdk.load_checkpoint(path)
+        for key in ['theta_history', 'theta_best', 'best_step', 'last_step',
+                     'loss_history', 'efficiency_history', 'grad_max_history']:
+            assert key in ckpt, f"Missing: {key}"
+
+    def test_theta_history_shape(self, configure_sdk, tmp_dir):
+        path = os.path.join(tmp_dir, "ckpt.npz")
+        self._run_and_save(configure_sdk, path, num_steps=15)
+        ckpt = configure_sdk.load_checkpoint(path)
+        assert ckpt['theta_history'].shape == (15, *THETA_SHAPE)
+
+    def test_histories_length(self, configure_sdk, tmp_dir):
+        path = os.path.join(tmp_dir, "ckpt.npz")
+        self._run_and_save(configure_sdk, path, num_steps=15)
+        ckpt = configure_sdk.load_checkpoint(path)
+        assert len(ckpt['loss_history']) == 15
+        assert len(ckpt['efficiency_history']) == 15
+        assert len(ckpt['grad_max_history']) == 15
+
+    def test_best_step_valid(self, configure_sdk, tmp_dir):
+        path = os.path.join(tmp_dir, "ckpt.npz")
+        self._run_and_save(configure_sdk, path, num_steps=15)
+        ckpt = configure_sdk.load_checkpoint(path)
+        assert 0 <= ckpt['best_step'] < 15
+        np.testing.assert_array_equal(ckpt['theta_best'], ckpt['theta_history'][ckpt['best_step']])
+
+    def test_opt_state_present(self, configure_sdk, tmp_dir):
+        path = os.path.join(tmp_dir, "ckpt.npz")
+        self._run_and_save(configure_sdk, path)
+        ckpt = configure_sdk.load_checkpoint(path)
+        assert 'opt_state_b64' in ckpt
+        assert len(ckpt['opt_state_b64']) > 0
+
+    def test_metadata(self, configure_sdk, tmp_dir):
+        path = os.path.join(tmp_dir, "ckpt.npz")
+        self._run_and_save(configure_sdk, path)
+        ckpt = configure_sdk.load_checkpoint(path)
+        assert 'metadata_json' in ckpt
+        assert 'timestamp' in ckpt['metadata_json']
+
+    def test_empty_results_raises(self, configure_sdk):
+        with pytest.raises(ValueError, match="empty"):
+            configure_sdk.save_checkpoint([], "/tmp/bad.npz")
+
+    def test_missing_file_raises(self, configure_sdk):
+        with pytest.raises(FileNotFoundError):
+            configure_sdk.load_checkpoint("/tmp/nonexistent_xyz.npz")

--- a/tests/integration/test_04_boundary_resume.py
+++ b/tests/integration/test_04_boundary_resume.py
@@ -1,0 +1,48 @@
+"""Test 04: Boundary edge cases for resume."""
+
+import os
+import numpy as np
+import pytest
+from .helpers import make_test_inputs, run_opt, THETA_SHAPE
+
+
+class TestBoundaryResume:
+    def test_single_step(self, configure_sdk):
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        results = run_opt(hwc, theta, source, num_steps=1)
+        assert len(results) == 1
+        assert results[0]['step'] == 0
+
+    def test_resume_last_step(self, configure_sdk, tmp_dir):
+        """Resume from step 28 for total 30 should yield 1 step."""
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        ckpt = os.path.join(tmp_dir, "ckpt29.npz")
+
+        r1 = run_opt(hwc, theta, source, num_steps=29)
+        assert len(r1) == 29
+        hwc.save_checkpoint(r1, ckpt)
+
+        r2 = run_opt(hwc, None, source, num_steps=30, checkpoint=ckpt)
+        assert len(r2) == 1
+
+    def test_double_checkpoint(self, configure_sdk, tmp_dir):
+        """Save, resume, save again, resume again."""
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        ckpt1 = os.path.join(tmp_dir, "ckpt1.npz")
+        ckpt2 = os.path.join(tmp_dir, "ckpt2.npz")
+
+        r1 = run_opt(hwc, theta, source, num_steps=10)
+        hwc.save_checkpoint(r1, ckpt1)
+
+        r2 = run_opt(hwc, None, source, num_steps=15, checkpoint=ckpt1)
+        assert len(r2) == 5
+        hwc.save_checkpoint(r1 + r2, ckpt2)
+
+        r3 = run_opt(hwc, None, source, num_steps=20, checkpoint=ckpt2)
+        assert len(r3) == 5
+
+        all_steps = [r['step'] for r in r1 + r2 + r3]
+        assert all_steps == list(range(20))

--- a/tests/integration/test_05_multi_segment.py
+++ b/tests/integration/test_05_multi_segment.py
@@ -1,0 +1,76 @@
+"""Test 05: Multiple save/load cycles (10+10+10)."""
+
+import os
+import numpy as np
+import pytest
+from .helpers import make_test_inputs, run_opt, NUM_STEPS, THETA_SHAPE
+
+
+class TestMultiSegment:
+    def test_three_segments_loss_decreasing(self, configure_sdk, tmp_dir):
+        """Loss should decrease across all 3 segments despite LR restarts."""
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+
+        ckpt1 = os.path.join(tmp_dir, "seg1.npz")
+        ckpt2 = os.path.join(tmp_dir, "seg2.npz")
+
+        seg1 = run_opt(hwc, theta, source, num_steps=10)
+        hwc.save_checkpoint(seg1, ckpt1)
+
+        seg2 = run_opt(hwc, None, source, num_steps=20, checkpoint=ckpt1)
+        hwc.save_checkpoint(seg1 + seg2, ckpt2)
+
+        seg3 = run_opt(hwc, None, source, num_steps=30, checkpoint=ckpt2)
+
+        all_losses = np.array([r['loss'] for r in seg1 + seg2 + seg3])
+        assert len(all_losses) == 30
+
+        # Overall loss should decrease
+        assert all_losses[-1] < all_losses[0], "Loss did not decrease overall"
+
+        # No huge spikes at resume boundaries
+        last_seg1 = seg1[-1]['loss']
+        first_seg2 = seg2[0]['loss']
+        assert first_seg2 < last_seg1 * 1.5, (
+            f"Loss spike at seg1->seg2: {last_seg1:.6f} -> {first_seg2:.6f}"
+        )
+
+        last_seg2 = seg2[-1]['loss']
+        first_seg3 = seg3[0]['loss']
+        assert first_seg3 < last_seg2 * 1.5, (
+            f"Loss spike at seg2->seg3: {last_seg2:.6f} -> {first_seg3:.6f}"
+        )
+
+    def test_step_continuity(self, configure_sdk, tmp_dir):
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        ckpt = os.path.join(tmp_dir, "seg.npz")
+
+        seg1 = run_opt(hwc, theta, source, num_steps=10)
+        hwc.save_checkpoint(seg1, ckpt)
+
+        seg2 = run_opt(hwc, None, source, num_steps=20, checkpoint=ckpt)
+        hwc.save_checkpoint(seg1 + seg2, ckpt)
+
+        seg3 = run_opt(hwc, None, source, num_steps=30, checkpoint=ckpt)
+
+        all_steps = [r['step'] for r in seg1 + seg2 + seg3]
+        assert all_steps == list(range(30))
+
+    def test_segment_lengths_correct(self, configure_sdk, tmp_dir):
+        """Each segment should have the correct number of steps."""
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        ckpt = os.path.join(tmp_dir, "seg.npz")
+
+        seg1 = run_opt(hwc, theta, source, num_steps=10)
+        assert len(seg1) == 10
+        hwc.save_checkpoint(seg1, ckpt)
+
+        seg2 = run_opt(hwc, None, source, num_steps=20, checkpoint=ckpt)
+        assert len(seg2) == 10
+        hwc.save_checkpoint(seg1 + seg2, ckpt)
+
+        seg3 = run_opt(hwc, None, source, num_steps=30, checkpoint=ckpt)
+        assert len(seg3) == 10

--- a/tests/integration/test_06_billing.py
+++ b/tests/integration/test_06_billing.py
@@ -1,0 +1,62 @@
+"""Test 06: Billing verification."""
+
+import os
+import numpy as np
+import pytest
+import requests
+from .helpers import make_test_inputs, run_opt, THETA_SHAPE
+
+
+class TestBilling:
+    def test_full_run_billed(self, configure_sdk, mock_server):
+        theta, source = make_test_inputs()
+        run_opt(configure_sdk, theta, source, 30)
+        billing = requests.get(f"{mock_server}/billing").json()
+        assert len(billing) == 1
+        assert billing[0]['status'] == 'completed'
+        assert billing[0]['steps_completed'] == 30
+
+    def test_partial_run_billed(self, configure_sdk, mock_server):
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        count = 0
+        for step_result in hwc.run_optimization(
+            theta=theta,
+            source_field=source,
+            source_offset=(0, 0, 0),
+            freq_band=(0.196, 0.209, 2),
+            structure_spec={"layers_info": [], "construction_params": {"grid_shape": list(THETA_SHAPE)}},
+            loss_monitor_shape=(1, 1, 1),
+            loss_monitor_offset=(0, 0, 0),
+            design_monitor_shape=(1, 1, 1),
+            design_monitor_offset=(0, 0, 0),
+            mode_field=source,
+            input_power=1.0,
+            mode_cross_power=0.5,
+            num_steps=30,
+            learning_rate=0.01,
+            gpu_type="B200",
+            auto_checkpoint=False,
+        ):
+            count += 1
+            if count >= 10:
+                break
+
+        billing = requests.get(f"{mock_server}/billing").json()
+        assert len(billing) >= 1
+        last = billing[-1]
+        assert last['steps_completed'] >= 10
+
+    def test_resume_billing_separate(self, configure_sdk, mock_server, tmp_dir):
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        ckpt = os.path.join(tmp_dir, "ckpt.npz")
+
+        r1 = run_opt(hwc, theta, source, 15)
+        hwc.save_checkpoint(r1, ckpt)
+        r2 = run_opt(hwc, None, source, 30, checkpoint=ckpt)
+
+        billing = requests.get(f"{mock_server}/billing").json()
+        assert len(billing) == 2
+        assert billing[0]['steps_completed'] == 15
+        assert billing[1]['steps_completed'] == 15

--- a/tests/integration/test_07_cosine_lr.py
+++ b/tests/integration/test_07_cosine_lr.py
@@ -1,64 +1,37 @@
-"""Test 07: Cosine LR schedule continuity on resume."""
+"""Test 07: Constant LR (vanilla Adam) - verify LR is constant across run and resume."""
 
 import os
-import math
 import numpy as np
 import pytest
-from .helpers import make_test_inputs, run_opt, NUM_STEPS, THETA_SHAPE
+from .helpers import make_test_inputs, run_opt, NUM_STEPS
 
 
-def expected_cosine_lr(step, total_steps, init_lr=0.01, alpha=0.1):
-    if total_steps <= 1:
-        return init_lr
-    progress = min(step / (total_steps - 1), 1.0)
-    return init_lr * (alpha + (1 - alpha) * 0.5 * (1 + math.cos(math.pi * progress)))
-
-
-class TestCosineLR:
-    def test_full_run_lr_curve(self, configure_sdk):
+class TestConstantLR:
+    def test_full_run_constant_lr(self, configure_sdk):
+        """All steps should use the same learning rate."""
         theta, source = make_test_inputs()
         results = run_opt(configure_sdk, theta, source, NUM_STEPS)
         if 'lr' not in results[0]:
             pytest.skip("lr not in response")
 
         lrs = [r['lr'] for r in results]
-        assert lrs[0] > lrs[-1]
-
         for i, lr in enumerate(lrs):
-            expected = expected_cosine_lr(i, NUM_STEPS)
-            np.testing.assert_allclose(lr, expected, rtol=1e-4,
-                                       err_msg=f"LR mismatch at step {i}")
+            np.testing.assert_allclose(lr, 0.01, rtol=1e-4,
+                                       err_msg=f"LR not constant at step {i}")
 
-    def test_resumed_lr_is_fresh_cosine(self, configure_sdk, tmp_dir):
-        """Resumed run should have a fresh cosine schedule over remaining_steps.
-
-        This is by design: the server creates a new cosine schedule for
-        remaining_steps = num_steps - start_step, so LR starts high again
-        but decays over fewer steps.
-        """
+    def test_resumed_lr_same_as_initial(self, configure_sdk, tmp_dir):
+        """Resumed run should use the same constant LR."""
         hwc = configure_sdk
         theta, source = make_test_inputs()
         ckpt = os.path.join(tmp_dir, "ckpt_lr.npz")
 
-        # Phase 1: 15 steps
         r1 = run_opt(hwc, theta, source, 15)
         if 'lr' not in r1[0]:
             pytest.skip("lr not in response")
         hwc.save_checkpoint(r1, ckpt)
 
-        # Verify phase 1 LR is cosine over 15 steps
-        lrs_p1 = [r['lr'] for r in r1]
-        for i, lr in enumerate(lrs_p1):
-            expected = expected_cosine_lr(i, 15)
-            np.testing.assert_allclose(lr, expected, rtol=1e-4,
-                                       err_msg=f"Phase 1 LR mismatch at step {i}")
-
-        # Phase 2: resume from step 15, total 30 -> 15 remaining
         r2 = run_opt(hwc, None, source, NUM_STEPS, checkpoint=ckpt)
-        lrs_p2 = [r['lr'] for r in r2]
-
-        # Phase 2 should be a fresh cosine over 15 remaining steps
-        for i, lr in enumerate(lrs_p2):
-            expected = expected_cosine_lr(i, 15)
-            np.testing.assert_allclose(lr, expected, rtol=1e-4,
-                                       err_msg=f"Phase 2 LR mismatch at step {i}")
+        lrs = [r['lr'] for r in r1 + r2]
+        for i, lr in enumerate(lrs):
+            np.testing.assert_allclose(lr, 0.01, rtol=1e-4,
+                                       err_msg=f"LR not constant at step {i}")

--- a/tests/integration/test_07_cosine_lr.py
+++ b/tests/integration/test_07_cosine_lr.py
@@ -1,0 +1,64 @@
+"""Test 07: Cosine LR schedule continuity on resume."""
+
+import os
+import math
+import numpy as np
+import pytest
+from .helpers import make_test_inputs, run_opt, NUM_STEPS, THETA_SHAPE
+
+
+def expected_cosine_lr(step, total_steps, init_lr=0.01, alpha=0.1):
+    if total_steps <= 1:
+        return init_lr
+    progress = min(step / (total_steps - 1), 1.0)
+    return init_lr * (alpha + (1 - alpha) * 0.5 * (1 + math.cos(math.pi * progress)))
+
+
+class TestCosineLR:
+    def test_full_run_lr_curve(self, configure_sdk):
+        theta, source = make_test_inputs()
+        results = run_opt(configure_sdk, theta, source, NUM_STEPS)
+        if 'lr' not in results[0]:
+            pytest.skip("lr not in response")
+
+        lrs = [r['lr'] for r in results]
+        assert lrs[0] > lrs[-1]
+
+        for i, lr in enumerate(lrs):
+            expected = expected_cosine_lr(i, NUM_STEPS)
+            np.testing.assert_allclose(lr, expected, rtol=1e-4,
+                                       err_msg=f"LR mismatch at step {i}")
+
+    def test_resumed_lr_is_fresh_cosine(self, configure_sdk, tmp_dir):
+        """Resumed run should have a fresh cosine schedule over remaining_steps.
+
+        This is by design: the server creates a new cosine schedule for
+        remaining_steps = num_steps - start_step, so LR starts high again
+        but decays over fewer steps.
+        """
+        hwc = configure_sdk
+        theta, source = make_test_inputs()
+        ckpt = os.path.join(tmp_dir, "ckpt_lr.npz")
+
+        # Phase 1: 15 steps
+        r1 = run_opt(hwc, theta, source, 15)
+        if 'lr' not in r1[0]:
+            pytest.skip("lr not in response")
+        hwc.save_checkpoint(r1, ckpt)
+
+        # Verify phase 1 LR is cosine over 15 steps
+        lrs_p1 = [r['lr'] for r in r1]
+        for i, lr in enumerate(lrs_p1):
+            expected = expected_cosine_lr(i, 15)
+            np.testing.assert_allclose(lr, expected, rtol=1e-4,
+                                       err_msg=f"Phase 1 LR mismatch at step {i}")
+
+        # Phase 2: resume from step 15, total 30 -> 15 remaining
+        r2 = run_opt(hwc, None, source, NUM_STEPS, checkpoint=ckpt)
+        lrs_p2 = [r['lr'] for r in r2]
+
+        # Phase 2 should be a fresh cosine over 15 remaining steps
+        for i, lr in enumerate(lrs_p2):
+            expected = expected_cosine_lr(i, 15)
+            np.testing.assert_allclose(lr, expected, rtol=1e-4,
+                                       err_msg=f"Phase 2 LR mismatch at step {i}")

--- a/tests/integration/test_08_websocket_fix.py
+++ b/tests/integration/test_08_websocket_fix.py
@@ -1,0 +1,34 @@
+"""Test 08: WebSocket gateway URL fix (unit test)."""
+
+import pytest
+
+
+class TestWebSocketURLFix:
+    def test_gateway_url_none_fallback(self):
+        from hyperwave_community.api_client import _API_CONFIG
+        original = _API_CONFIG.copy()
+        try:
+            _API_CONFIG['api_url'] = 'https://example.com'
+            _API_CONFIG['gateway_url'] = None
+            result = _API_CONFIG.get('gateway_url') or _API_CONFIG['api_url']
+            assert result == 'https://example.com'
+        finally:
+            _API_CONFIG.update(original)
+
+    def test_gateway_url_set(self):
+        from hyperwave_community.api_client import _API_CONFIG
+        original = _API_CONFIG.copy()
+        try:
+            _API_CONFIG['api_url'] = 'https://api.example.com'
+            _API_CONFIG['gateway_url'] = 'https://gateway.example.com'
+            result = _API_CONFIG.get('gateway_url') or _API_CONFIG['api_url']
+            assert result == 'https://gateway.example.com'
+        finally:
+            _API_CONFIG.update(original)
+
+    def test_old_pattern_broken(self):
+        config = {'gateway_url': None, 'api_url': 'https://fallback.com'}
+        old_result = config.get('gateway_url', 'https://fallback.com')
+        assert old_result is None
+        new_result = config.get('gateway_url') or config['api_url']
+        assert new_result == 'https://fallback.com'


### PR DESCRIPTION
## Summary
- Add save_checkpoint/load_checkpoint for optimization state persistence
- Fix off-by-one in start_step calculation (last_step + 1)
- Add run_optimization checkpoint and auto_checkpoint parameters
- Add 32 integration tests covering resume, billing, LR, boundary cases

## Test plan
- [x] 32 integration tests passing against local mock server
- [ ] Railway preview deploy testing
- [ ] Colab manual testing