### PR TITLE
Retry optimize() startup on transient gateway timeout (+ hardening)

### DIFF
--- a/hyperwave_community/pipeline.py
+++ b/hyperwave_community/pipeline.py
@@ -34,6 +34,22 @@ def compute_mode_cross_power(mode_field: np.ndarray) -> float:
 # optimize() - cloud GPU
 # ---------------------------------------------------------------------------
 
+# Startup-timeout retry: when the gateway's billing/validate call exceeds its
+# own timeout during session startup, it returns an error ack reading
+# "...timed out". At that point the GPU job has NOT been dispatched, so
+# reconnecting is safe and cannot create a duplicate run. Such transient
+# timeouts are retried with exponential backoff; genuine server errors are not.
+_MAX_STARTUP_RETRIES = 3
+_STARTUP_BACKOFF_BASE = 2.0  # seconds between attempts: 2, 4, 8
+
+
+def _is_transient_startup_timeout(message: str) -> bool:
+    """True if a startup-ack error message indicates a transient timeout
+    (gateway / Cloud Function cold-start) that is safe to retry, as opposed to a
+    genuine server error (e.g. "bad request: invalid phase") that must not be."""
+    return "timed out" in (message or "").lower()
+
+
 def optimize(
     layers: Any = None,
     theta: Optional[Dict[str, np.ndarray]] = None,
@@ -377,27 +393,49 @@ def optimize(
 
     ws = None
 
-    # Try unified WebSocket first, fall back to 2-step POST+WS
-    try:
-        ws_url = GATEWAY_URL.replace("https://", "wss://").replace("http://", "ws://")
-        ws_url = f"{ws_url}/pipeline_optimize_ws"
-        ws = _ws_lib.create_connection(
-            ws_url, header={"X-API-Key": effective_api_key}, timeout=60)
-        if len(compressed) < len(body):
-            ws.send_binary(compressed)
-        else:
-            ws.send(body.decode())
-        ack_raw = ws.recv()
-        ack = json.loads(ack_raw)
-        if ack.get("type") == "error":
-            ws.close()
-            raise RuntimeError(ack.get("message", "Server error during startup"))
-        if ack.get("type") != "started":
-            ws.close()
-            raise RuntimeError(f"Unexpected ack from server: {ack}")
-        logger.info("  Session started in %.1fs (unified WS)", _time.time() - t0)
-    except (OSError, _ws_lib.WebSocketException, ConnectionError, TimeoutError) as e:
-        logger.warning("  Unified WS failed (%s), falling back to 2-step flow...", e)
+    # Try the unified WebSocket first, falling back to the 2-step POST+WS flow
+    # on connection-level failures. A transient gateway/cold-start timeout at the
+    # startup ack is retried with exponential backoff (see
+    # _is_transient_startup_timeout / _MAX_STARTUP_RETRIES); genuine server
+    # errors are raised immediately.
+    _unified_started = False
+    _conn_err = None
+    for _attempt in range(_MAX_STARTUP_RETRIES + 1):
+        try:
+            ws_url = GATEWAY_URL.replace("https://", "wss://").replace("http://", "ws://")
+            ws_url = f"{ws_url}/pipeline_optimize_ws"
+            ws = _ws_lib.create_connection(
+                ws_url, header={"X-API-Key": effective_api_key}, timeout=60)
+            if len(compressed) < len(body):
+                ws.send_binary(compressed)
+            else:
+                ws.send(body.decode())
+            ack_raw = ws.recv()
+            ack = json.loads(ack_raw)
+            if ack.get("type") == "error":
+                ws.close()
+                _err_msg = ack.get("message", "Server error during startup")
+                if _is_transient_startup_timeout(_err_msg) and _attempt < _MAX_STARTUP_RETRIES:
+                    _backoff = _STARTUP_BACKOFF_BASE * (2 ** _attempt)
+                    logger.warning(
+                        "  Startup timed out (%s); retrying in %.0fs (attempt %d/%d)...",
+                        _err_msg, _backoff, _attempt + 1, _MAX_STARTUP_RETRIES)
+                    _time.sleep(_backoff)
+                    continue
+                raise RuntimeError(_err_msg)
+            if ack.get("type") != "started":
+                ws.close()
+                raise RuntimeError(f"Unexpected ack from server: {ack}")
+            logger.info("  Session started in %.1fs (unified WS)", _time.time() - t0)
+            _unified_started = True
+            break
+        except (OSError, _ws_lib.WebSocketException, ConnectionError, TimeoutError) as e:
+            _conn_err = e
+            break
+
+    if not _unified_started:
+        # Unified WS hit a connection-level failure -> 2-step POST + WS fallback.
+        logger.warning("  Unified WS failed (%s), falling back to 2-step flow...", _conn_err)
         if ws is not None:
             try:
                 ws.close()

--- a/hyperwave_community/pipeline.py
+++ b/hyperwave_community/pipeline.py
@@ -34,20 +34,58 @@ def compute_mode_cross_power(mode_field: np.ndarray) -> float:
 # optimize() - cloud GPU
 # ---------------------------------------------------------------------------
 
-# Startup-timeout retry: when the gateway's billing/validate call exceeds its
-# own timeout during session startup, it returns an error ack reading
-# "...timed out". At that point the GPU job has NOT been dispatched, so
-# reconnecting is safe and cannot create a duplicate run. Such transient
-# timeouts are retried with exponential backoff; genuine server errors are not.
+# Startup retry: the gateway emits an error ack for several transient,
+# PRE-DISPATCH failures during session startup (billing/validate cold-start,
+# the gateway->Cloud Function hop hitting an upstream 5xx/connect hiccup, or a
+# payload-receive timeout). SAFETY: in the gateway's /pipeline_optimize_ws
+# handler EVERY startup error ack is sent BEFORE the Modal GPU job is dispatched
+# (see hyperwave-cloud app.py: validate/error-ack at ~5467/5510/5516, dispatch
+# at ~5567, "started" ack at ~5604). So a reconnect on any of these acks cannot
+# create a duplicate GPU run. Post-dispatch errors arrive only via the streaming
+# loop (NOT this startup ack) and are never retried here. Genuine errors
+# (invalid api key, insufficient credits, gzip/validation/bad request, auth)
+# match none of the signatures below and still raise immediately.
 _MAX_STARTUP_RETRIES = 3
 _STARTUP_BACKOFF_BASE = 2.0  # seconds between attempts: 2, 4, 8
 
+# Substrings (case-insensitive) marking a transient, retry-safe startup ack.
+# Grounded in the real strings hyperwave-cloud emits (app.py make_authorized_request
+# + the /pipeline_optimize_ws startup): "Request to Cloud Function timed out"
+# (httpx timeout), "Error calling Cloud Function: upstream request timeout" /
+# DEADLINE_EXCEEDED (upstream 5xx body), "All connection attempts failed" /
+# "Server disconnected without sending a response." (httpx connect/disconnect),
+# and "Timed out waiting for request payload". A rare false positive only costs
+# the backoff delay before failing -- never a wrong result.
+_TRANSIENT_STARTUP_SIGNATURES = (
+    "timed out",
+    "timeout",
+    "deadline exceeded",
+    "connection attempts failed",
+    "server disconnected",
+    "service unavailable",
+    "temporarily unavailable",
+)
+
 
 def _is_transient_startup_timeout(message: str) -> bool:
-    """True if a startup-ack error message indicates a transient timeout
-    (gateway / Cloud Function cold-start) that is safe to retry, as opposed to a
-    genuine server error (e.g. "bad request: invalid phase") that must not be."""
-    return "timed out" in (message or "").lower()
+    """True if a startup-ack error message indicates a transient, pre-dispatch
+    failure (gateway/Cloud Function cold-start, upstream 5xx/connect hiccup, or
+    payload-receive timeout) that is safe to retry. Genuine server errors
+    (bad request, invalid phase, invalid api key, insufficient credits) match
+    none of the signatures and still raise immediately on the first attempt."""
+    m = (message or "").lower()
+    return any(sig in m for sig in _TRANSIENT_STARTUP_SIGNATURES)
+
+
+def _safe_close(ws) -> None:
+    """Close a websocket, swallowing any error. A close() that raised would be
+    caught by the connect-error handler and could hijack a transient-timeout
+    retry into the POST fallback (losing the precise error); guarding it keeps
+    the retry path deterministic."""
+    try:
+        ws.close()
+    except Exception:
+        pass
 
 
 def optimize(
@@ -411,20 +449,29 @@ def optimize(
             else:
                 ws.send(body.decode())
             ack_raw = ws.recv()
-            ack = json.loads(ack_raw)
+            try:
+                ack = json.loads(ack_raw)
+            except (ValueError, TypeError):
+                # Non-JSON / empty first frame (e.g. a clean close or proxy
+                # frame). Close to avoid leaking the socket and fail fast --
+                # this is a protocol error, not a retryable transient.
+                _safe_close(ws)
+                raise RuntimeError(
+                    "Malformed startup ack from server (not JSON): "
+                    f"{repr(ack_raw)[:200]}")
             if ack.get("type") == "error":
-                ws.close()
+                _safe_close(ws)
                 _err_msg = ack.get("message", "Server error during startup")
                 if _is_transient_startup_timeout(_err_msg) and _attempt < _MAX_STARTUP_RETRIES:
                     _backoff = _STARTUP_BACKOFF_BASE * (2 ** _attempt)
                     logger.warning(
-                        "  Startup timed out (%s); retrying in %.0fs (attempt %d/%d)...",
+                        "  Transient startup error (%s); retrying in %.0fs (attempt %d/%d)...",
                         _err_msg, _backoff, _attempt + 1, _MAX_STARTUP_RETRIES)
                     _time.sleep(_backoff)
                     continue
                 raise RuntimeError(_err_msg)
             if ack.get("type") != "started":
-                ws.close()
+                _safe_close(ws)
                 raise RuntimeError(f"Unexpected ack from server: {ack}")
             logger.info("  Session started in %.1fs (unified WS)", _time.time() - t0)
             _unified_started = True

--- a/tests/test_optimize_fallback.py
+++ b/tests/test_optimize_fallback.py
@@ -472,9 +472,16 @@ def test_startup_timeout_retries_then_succeeds(mock_create_conn, mock_post):
     assert "/pipeline_optimize_ws" in mock_create_conn.call_args_list[0][0][0]
     assert "/pipeline_optimize_ws" in mock_create_conn.call_args_list[1][0][0]
 
-    # Backoff slept at least once, and the timed-out socket was closed.
-    assert mock_sleep.called
+    # Backoff slept exactly once with the first exponential delay (2s), and the
+    # timed-out socket was closed.
+    from hyperwave_community.pipeline import _STARTUP_BACKOFF_BASE
+    mock_sleep.assert_called_once_with(_STARTUP_BACKOFF_BASE)
     assert first_ws._closed
+
+    # The original payload was resent verbatim, exactly once, on the retry.
+    assert len(first_ws._sent) == 1
+    assert len(good_ws._sent) == 1
+    assert first_ws._sent == good_ws._sent
 
     # No POST fallback was used (this is a startup retry, not a connection error).
     mock_post.assert_not_called()
@@ -502,12 +509,17 @@ def test_startup_timeout_exhausts_retries_raises(mock_create_conn, mock_post):
         MockWebSocket([dict(timeout_ack)]) for _ in range(_MAX_STARTUP_RETRIES + 1)
     ]
 
-    with patch("time.sleep"):
+    from hyperwave_community.pipeline import _STARTUP_BACKOFF_BASE
+    with patch("time.sleep") as mock_sleep:
         with pytest.raises(RuntimeError, match="timed out"):
             _call_optimize()
 
     # Exactly initial attempt + N retries.
     assert mock_create_conn.call_count == _MAX_STARTUP_RETRIES + 1
+    # Backoff is exponential 2/4/8s: one sleep per retry, none after the final
+    # failed attempt.
+    expected = [_STARTUP_BACKOFF_BASE * (2 ** i) for i in range(_MAX_STARTUP_RETRIES)]
+    assert [c.args[0] for c in mock_sleep.call_args_list] == expected
     # Startup retry never falls back to POST.
     mock_post.assert_not_called()
 
@@ -534,5 +546,87 @@ def test_genuine_server_error_does_not_retry(mock_create_conn, mock_post):
 
     # Only one connection attempt -- no retry, no backoff.
     assert mock_create_conn.call_count == 1
+    mock_sleep.assert_not_called()
+    mock_post.assert_not_called()
+
+
+# ===================================================================
+# 14. Transient PRE-DISPATCH siblings (not the literal "timed out") also retry
+# ===================================================================
+
+@pytest.mark.parametrize("transient_msg", [
+    "Error calling Cloud Function: upstream request timeout",   # upstream 504 body
+    "All connection attempts failed",                            # httpx ConnectError
+    "4 DEADLINE_EXCEEDED: Deadline exceeded",                    # gRPC deadline
+    "Server disconnected without sending a response.",           # httpx disconnect
+    "Timed out waiting for request payload",                     # payload-receive timeout
+])
+@patch("requests.post")
+@patch("websocket.create_connection")
+def test_startup_retries_on_transient_siblings(mock_create_conn, mock_post, transient_msg):
+    """Pre-dispatch transients other than the literal 'Request ... timed out'
+    string are equally safe to retry (same pre-dispatch billing/validate path)."""
+    err_ack = {"type": "error", "message": transient_msg}
+    first_ws = MockWebSocket([dict(err_ack)])
+    good_ws = MockWebSocket([_STARTED_MSG, _STEP_MSG, _DONE_MSG])
+    mock_create_conn.side_effect = [first_ws, good_ws]
+
+    with patch("time.sleep") as mock_sleep:
+        result = _call_optimize()
+
+    assert mock_create_conn.call_count == 2           # reconnected and retried
+    assert mock_sleep.call_count == 1
+    mock_post.assert_not_called()                     # not a connection-error fallback
+    assert len(result.history) == 1
+
+
+# ===================================================================
+# 15. Non-transient billing rejection raises immediately, no retry
+# ===================================================================
+
+@patch("requests.post")
+@patch("websocket.create_connection")
+def test_insufficient_credits_not_retried(mock_create_conn, mock_post):
+    """A billing rejection carries no transient signature -> raise on attempt 1,
+    no backoff, no second connection (don't burn 14s retrying a hard 'no')."""
+    err_ack = {"type": "error",
+               "message": "Insufficient credits. Purchase at spinsphotonics.com"}
+    mock_create_conn.side_effect = [
+        MockWebSocket([dict(err_ack)]),
+        MockWebSocket([_STARTED_MSG, _STEP_MSG, _DONE_MSG]),  # must never be used
+    ]
+
+    with patch("time.sleep") as mock_sleep:
+        with pytest.raises(RuntimeError, match="Insufficient credits"):
+            _call_optimize()
+
+    assert mock_create_conn.call_count == 1
+    mock_sleep.assert_not_called()
+    mock_post.assert_not_called()
+
+
+# ===================================================================
+# 16. Malformed (non-JSON) startup ack closes the socket and fails fast
+# ===================================================================
+
+@patch("requests.post")
+@patch("websocket.create_connection")
+def test_malformed_startup_ack_raises_and_closes(mock_create_conn, mock_post):
+    """A non-JSON first frame must not leak the socket and must not be retried
+    (it is a protocol error, not a transient)."""
+    class BadAckWebSocket(MockWebSocket):
+        def recv(self):
+            return "<html>502 Bad Gateway</html>"  # not JSON
+
+    ws = BadAckWebSocket([])
+    mock_create_conn.side_effect = [ws,
+                                    MockWebSocket([_STARTED_MSG, _STEP_MSG, _DONE_MSG])]
+
+    with patch("time.sleep") as mock_sleep:
+        with pytest.raises(RuntimeError, match="Malformed startup ack"):
+            _call_optimize()
+
+    assert mock_create_conn.call_count == 1   # not retried
+    assert ws._closed                          # socket closed, not leaked
     mock_sleep.assert_not_called()
     mock_post.assert_not_called()

--- a/tests/test_optimize_fallback.py
+++ b/tests/test_optimize_fallback.py
@@ -444,3 +444,95 @@ def test_multilayer_theta_b64_dict(mock_create_conn):
     expected = np.full((_NX, _NY), 0.5, dtype=np.float32)
     np.testing.assert_array_equal(result.design.thetas["etch"], expected)
     np.testing.assert_array_equal(result.design.thetas["slab"], expected)
+
+
+# ===================================================================
+# 11. Startup ack is a transient "timed out" error -> retry, then succeed
+# ===================================================================
+
+@patch("requests.post")
+@patch("websocket.create_connection")
+def test_startup_timeout_retries_then_succeeds(mock_create_conn, mock_post):
+    """A startup ack of {'type':'error','message':'...timed out'} is a transient
+    gateway/cold-start timeout. optimize() should reconnect and retry the full
+    connect+send+ack sequence (with backoff) rather than failing the call."""
+    from hyperwave_community.pipeline import _MAX_STARTUP_RETRIES
+
+    timeout_ack = {"type": "error", "message": "Request to Cloud Function timed out"}
+    first_ws = MockWebSocket([dict(timeout_ack)])
+    good_ws = MockWebSocket([_STARTED_MSG, _STEP_MSG, _DONE_MSG])
+    mock_create_conn.side_effect = [first_ws, good_ws]
+
+    # Patch sleep so the test does not actually wait for backoff.
+    with patch("time.sleep") as mock_sleep:
+        result = _call_optimize()
+
+    # Reconnected once: two create_connection calls, both to the unified WS.
+    assert mock_create_conn.call_count == 2
+    assert "/pipeline_optimize_ws" in mock_create_conn.call_args_list[0][0][0]
+    assert "/pipeline_optimize_ws" in mock_create_conn.call_args_list[1][0][0]
+
+    # Backoff slept at least once, and the timed-out socket was closed.
+    assert mock_sleep.called
+    assert first_ws._closed
+
+    # No POST fallback was used (this is a startup retry, not a connection error).
+    mock_post.assert_not_called()
+
+    # The retry produced a normal result.
+    assert len(result.history) == 1
+    assert result.history[0]["efficiency"] == 0.5
+    assert _MAX_STARTUP_RETRIES >= 1
+
+
+# ===================================================================
+# 12. Startup timeout that never clears -> raise after exhausting retries
+# ===================================================================
+
+@patch("requests.post")
+@patch("websocket.create_connection")
+def test_startup_timeout_exhausts_retries_raises(mock_create_conn, mock_post):
+    """If every startup attempt times out, optimize() must give up after
+    _MAX_STARTUP_RETRIES retries and raise (not loop forever)."""
+    from hyperwave_community.pipeline import _MAX_STARTUP_RETRIES
+
+    timeout_ack = {"type": "error", "message": "Request to Cloud Function timed out"}
+    # Enough timed-out sockets to cover every attempt (1 initial + N retries).
+    mock_create_conn.side_effect = [
+        MockWebSocket([dict(timeout_ack)]) for _ in range(_MAX_STARTUP_RETRIES + 1)
+    ]
+
+    with patch("time.sleep"):
+        with pytest.raises(RuntimeError, match="timed out"):
+            _call_optimize()
+
+    # Exactly initial attempt + N retries.
+    assert mock_create_conn.call_count == _MAX_STARTUP_RETRIES + 1
+    # Startup retry never falls back to POST.
+    mock_post.assert_not_called()
+
+
+# ===================================================================
+# 13. Genuine (non-timeout) server error still raises immediately, no retry
+# ===================================================================
+
+@patch("requests.post")
+@patch("websocket.create_connection")
+def test_genuine_server_error_does_not_retry(mock_create_conn, mock_post):
+    """A non-timeout error (e.g. bad request) must NOT be retried -- it should
+    raise immediately on the first attempt. Guards the retry from masking real
+    server errors. (Complements test_server_error_no_fallback.)"""
+    error_ack = {"type": "error", "message": "bad request: invalid phase"}
+    mock_create_conn.side_effect = [
+        MockWebSocket([dict(error_ack)]),
+        MockWebSocket([_STARTED_MSG, _STEP_MSG, _DONE_MSG]),  # must never be used
+    ]
+
+    with patch("time.sleep") as mock_sleep:
+        with pytest.raises(RuntimeError, match="bad request: invalid phase"):
+            _call_optimize()
+
+    # Only one connection attempt -- no retry, no backoff.
+    assert mock_create_conn.call_count == 1
+    mock_sleep.assert_not_called()
+    mock_post.assert_not_called()


### PR DESCRIPTION
Makes optimize() resilient to transient gateway/cold-start failures at session startup. Client SDK only; no backend touched.

Under Modal congestion the unified-WS startup ack returns a transient error (e.g. "Request to Cloud Function timed out") when the gateway billing/validate call cold-starts past its own timeout; the old code raised immediately and killed the call (hit 2x in one session; only manual re-run worked -> the GPU job had not dispatched, so reconnect is safe).

- Bounded retry loop around connect+send+ack: 3 retries, exp backoff 2/4/8s; retry ONLY on transient pre-dispatch signatures (timed out|timeout|deadline exceeded|connection attempts failed|server disconnected|service/temporarily unavailable), grounded in hyperwave-cloud app.py make_authorized_request. Genuine errors (bad request, invalid api key, insufficient credits) raise immediately.
- Safety: every gateway startup error ack is emitted BEFORE the Modal dispatch (app.py ~5467/5510/5516 < 5567 < started 5604), so a retried ack cannot double-dispatch (independently confirmed by a 50-agent adversarial review). Documented in the matcher comment.
- _safe_close + malformed-ack handling so the retry path can't leak a socket or get hijacked into the POST fallback. Existing unified-WS -> POST+WS fallback preserved unchanged.
- Tests: tests/test_optimize_fallback.py 13 -> 20. Pin 2/4/8s backoff, assert resent payload byte-identical/exactly-once, cover transient siblings + non-transient billing + malformed ack. Also live-smoke-validated against the real gateway (clean 1.4s startup).

Follow-up (separate, deploy-gated): server-side idempotency key as belt-and-suspenders.