### PR TITLE
Retire run_optimization(): fail loudly, point to optimize()

### DIFF
--- a/hyperwave_community/api_client.py
+++ b/hyperwave_community/api_client.py
@@ -2801,7 +2801,13 @@ def run_optimization(
     gpu_type: str = "B200",
     api_key: Optional[str] = None,
 ) -> 'Generator[Dict[str, Any], None, None]':
-    """Run optimization loop on cloud GPU.
+    """[RETIRED -- use hwc.optimize(layers=, theta=)] Legacy single-layer cloud optimizer.
+
+    This API is no longer available: its GPU backend (the structure_spec
+    streaming function behind /inverse_design_start) was never deployed, so
+    calling it raises RuntimeError. Migrate to hwc.optimize(layers=..., theta=...),
+    which runs the same adjoint inverse design on the maintained multilayer GPU
+    backend. The documentation below is retained for reference during migration.
 
     Sends all optimization parameters in a single request. The cloud GPU
     runs the full loop (forward + adjoint FDTD per step, Adam updates) and
@@ -2862,7 +2868,7 @@ def run_optimization(
             - is_final (bool): True on the last step.
 
     Raises:
-        ValueError: If no loss specification is provided.
+        RuntimeError: Always. This API is retired; use hwc.optimize() instead.
 
     Example:
         >>> results = []
@@ -2890,6 +2896,19 @@ def run_optimization(
         ... except KeyboardInterrupt:
         ...     print(f"Stopped after {len(results)} steps.")
     """
+    # RETIRED: the cloud backend for run_optimization() (the structure_spec
+    # streaming function behind /inverse_design_start) was never deployed, so
+    # this path cannot run and previously failed with a Modal lookup error and
+    # "No optimization steps completed". Fail loudly and point to optimize().
+    raise RuntimeError(
+        "hwc.run_optimization() has been retired and its cloud backend is no "
+        "longer available. Use hwc.optimize(layers=..., theta=...) instead, "
+        "which runs the same adjoint inverse design on the maintained GPU "
+        "backend. For a single design layer, pass a one-layer design stack (a "
+        "layer with design=True) plus your initial theta. See the "
+        "hwc.optimize() docstring or the inverse design tutorial for migration."
+    )
+
     import json
 
     effective_api_key = api_key or _API_CONFIG.get('api_key')

--- a/tests/test_new_api.py
+++ b/tests/test_new_api.py
@@ -539,3 +539,52 @@ class TestCheckpoint:
             loaded = load_checkpoint(path)
             np.testing.assert_array_equal(loaded.thetas["etch"], d.thetas["etch"])
             assert loaded.schedule_config["beta_init"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# run_optimization() is retired (legacy single-layer cloud API)
+# ---------------------------------------------------------------------------
+
+class TestRunOptimizationRetired:
+    """The legacy run_optimization() cloud path is dead: its GPU backend
+    (the structure_spec streaming function behind /inverse_design_start) was
+    never deployed. It must now fail loudly and point users to optimize()."""
+
+    def _minimal_kwargs(self):
+        return dict(
+            theta=np.zeros((4, 4), dtype=np.float32),
+            source_field=np.zeros((1, 6, 1, 4, 1), dtype=np.complex64),
+            source_offset=(0, 0, 0),
+            freq_band=(0.1, 0.1, 1),
+            structure_spec={},
+            loss_monitor_shape=(1, 4, 1), loss_monitor_offset=(0, 0, 0),
+            design_monitor_shape=(4, 4, 1), design_monitor_offset=(0, 0, 0),
+            mode_field=np.zeros((1, 6, 1, 4, 1), dtype=np.complex64),
+            input_power=1.0, mode_cross_power=1.0,
+        )
+
+    def test_run_optimization_raises_on_use(self):
+        """Iterating the generator raises RuntimeError mentioning optimize()."""
+        from hyperwave_community.api_client import run_optimization
+        gen = run_optimization(**self._minimal_kwargs())
+        with pytest.raises(RuntimeError, match="optimize"):
+            next(gen)
+
+    def test_message_is_actionable(self):
+        """Error says it is retired and names the replacement optimize() call."""
+        from hyperwave_community.api_client import run_optimization
+        with pytest.raises(RuntimeError) as exc:
+            list(run_optimization(**self._minimal_kwargs()))
+        msg = str(exc.value).lower()
+        assert ("retired" in msg) or ("no longer" in msg)
+        assert "optimize(" in msg
+
+    def test_retired_before_any_network_or_validation(self):
+        """Must raise before touching API config / network -- works with no key
+        configured and even with an otherwise-invalid loss spec."""
+        from hyperwave_community.api_client import run_optimization
+        kwargs = self._minimal_kwargs()
+        kwargs.pop("mode_field"); kwargs.pop("input_power"); kwargs.pop("mode_cross_power")
+        # No loss spec at all would normally ValueError; retirement preempts it.
+        with pytest.raises(RuntimeError, match="optimize"):
+            next(run_optimization(**kwargs))


### PR DESCRIPTION
run_optimization() (legacy single-layer cloud API) is dead end-to-end and now raises a clear error pointing users to optimize(layers=, theta=). Client SDK only; no backend/deploy.

Root cause: it POSTs to gateway /inverse_design_start, which resolves Modal fn optimize_from_spec_stream_b200 on app hyperwave-cloud-inverse-design -- a function that exists in ZERO source/commits (git log -S empty), never deployed. Both WS and SSE transports hit the same dead lookup -> "Lookup failed ... not found", 0 steps. Billing is safe (0 steps -> status=failed, timeUsed=0, not charged). This is the duplicate-GPU-fork problem from the arch review; rather than resurrect a second single-layer backend, retire the legacy API and steer to the maintained multilayer optimize() (-> /pipeline_optimize_ws -> optimize_multilayer_on_modal_stream @ hyperwave-inverse-design).

- run_optimization() now raises RuntimeError on first use (raise is the first statement; old impl left intact below, unreachable). Docstring marked [RETIRED]; Raises updated.
- Tests: tests/test_new_api.py +TestRunOptimizationRetired (3): raises on use, message is actionable (names optimize()), preempts the no-loss-spec ValueError. Full suite 59 passed.
- NOTE: examples/{test_inverse_design,test_notebook,test_notebook_25nm,test_interruption}.py + inverse_design_workflow.ipynb call run_optimization and will now raise -> migrate/archive separately.